### PR TITLE
[Feature] Workflow error handling and sharing data between steps

### DIFF
--- a/src/main/java/org/healtex/batch/exception/SkipFileException.java
+++ b/src/main/java/org/healtex/batch/exception/SkipFileException.java
@@ -1,0 +1,16 @@
+package org.healtex.batch.exception;
+
+public class SkipFileException extends Exception {
+
+    public SkipFileException() {
+        super();
+    }
+
+    public SkipFileException(String message) {
+        super(message);
+    }
+
+    public SkipFileException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/healtex/batch/listener/FirstPassSkipFileListener.java
+++ b/src/main/java/org/healtex/batch/listener/FirstPassSkipFileListener.java
@@ -1,0 +1,41 @@
+package org.healtex.batch.listener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.HashSet;
+import org.springframework.batch.core.listener.SkipListenerSupport;
+import org.springframework.stereotype.Component;
+
+import org.healtex.model.Document;
+import org.healtex.model.AnnotatedDocument;
+
+@Component
+public class FirstPassSkipFileListener extends SkipListenerSupport<Document, AnnotatedDocument> {
+
+    private static Set<String> skippedFileNames = new HashSet<String>();
+
+    public static Set<String> getSkippedFileNames() {
+        return FirstPassSkipFileListener.skippedFileNames;
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(FirstPassSkipFileListener.class);
+
+    @Override
+    public void onSkipInRead(java.lang.Throwable t) {
+        // TODO how to obtain the file name if read fails?
+    }
+
+    @Override
+    public void onSkipInProcess(Document item, java.lang.Throwable t) {
+        log.info("{} has been skipped in process()", item.getFileName());
+        FirstPassSkipFileListener.skippedFileNames.add(item.getFileName());
+    }
+
+    @Override
+    public void onSkipInWrite(AnnotatedDocument item, java.lang.Throwable t) {
+        log.info("{} has been skipped in write()", item.getFileName());
+        FirstPassSkipFileListener.skippedFileNames.add(item.getFileName());
+    }
+}

--- a/src/main/java/org/healtex/batch/listener/FirstPassStepExecutionListener.java
+++ b/src/main/java/org/healtex/batch/listener/FirstPassStepExecutionListener.java
@@ -21,16 +21,16 @@ public class FirstPassStepExecutionListener implements StepExecutionListener {
     }
 
     public ExitStatus afterStep(StepExecution stepExecution) {
-        log.info("Modify the step execution");
         ExecutionContext ec = stepExecution.getExecutionContext();
-
-        ArrayList<String> als = new ArrayList<String>();
-        ec.put("FAILED_LIST", als);
-        // TODO: Where to get list of failed id
-        // 1. task onError listener?
-        // 2. or processor remember it
-
-        // persist it someway
+        // Remarks:
+        //   Actually, if we use a static variable in FirstPassSkipFileListener
+        //   to store the names, it is overkill to use StepExecutionListener to
+        //   "pass" the names from step1 to step2. However, initially,
+        //   we took this approach because it may(?) work well in multi-host job.
+        //   Still, doing it this way has one advantage: the names are recorded
+        //   in the DB (if a job repo is used) for future checks.
+        ec.put("SKIPPED_FILE_NAMES",
+               FirstPassSkipFileListener.getSkippedFileNames());
         return null;
     }
 }

--- a/src/main/java/org/healtex/batch/listener/SecondPassStepExecutionListener.java
+++ b/src/main/java/org/healtex/batch/listener/SecondPassStepExecutionListener.java
@@ -1,7 +1,7 @@
 package org.healtex.batch.listener;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +25,12 @@ public class SecondPassStepExecutionListener implements StepExecutionListener {
         for (StepExecution se : ses) {
             if (se.getStepName().equals("step1")) {
                 ExecutionContext ec = se.getExecutionContext();
-                // TODO: do something with (ArrayList<String>) ec.get("FAILED_LIST");
+                Object storedContext = ec.get("SKIPPED_FILE_NAMES");
+                if (storedContext != null) {
+                    HashSet<String> failedNames = (HashSet<String>) storedContext;
+                    log.info("Obtained skipped file names: {}", storedContext.toString());
+                    // TODO this still seems an overkill.. leave it here for now.
+                }
             }
         }
     }

--- a/src/main/java/org/healtex/batch/processor/FirstPassItemProcessor.java
+++ b/src/main/java/org/healtex/batch/processor/FirstPassItemProcessor.java
@@ -1,5 +1,6 @@
 package org.healtex.batch.processor;
 
+import org.healtex.batch.exception.SkipFileException;
 import org.healtex.controller.NamedEntityExtractor;
 import org.healtex.model.AnnotatedDocument;
 import org.healtex.model.Document;
@@ -21,14 +22,18 @@ public class FirstPassItemProcessor implements ItemProcessor<Document, Annotated
 
     @Override
     public AnnotatedDocument process(final Document doc) throws Exception {
-
-        AnnotatedDocument annotatedDoc = new AnnotatedDocument();
-        annotatedDoc.setFileName(doc.getFileName());
-        annotatedDoc.setPerPersonDocumentId(doc.getPerPersonDocumentId());
-        annotatedDoc.setPersonId(doc.getPersonId());
-        annotatedDoc.setContent(doc.getContent());
-        namedEntityExtractor.run(annotatedDoc.getGateDocument());
-        return annotatedDoc;
+        // Catch all exception and replace by SkipFileException (which we explicitly allow the file to skip)
+        try {
+            AnnotatedDocument annotatedDoc = new AnnotatedDocument();
+            annotatedDoc.setFileName(doc.getFileName());
+            annotatedDoc.setPerPersonDocumentId(doc.getPerPersonDocumentId());
+            annotatedDoc.setPersonId(doc.getPersonId());
+            annotatedDoc.setContent(doc.getContent());
+            namedEntityExtractor.run(annotatedDoc.getGateDocument());
+            return annotatedDoc;
+        } catch (Exception ex) { // In the future, change this part to customize how to react to different exceptions
+            throw new SkipFileException(ex);
+        }
     }
 
 }

--- a/src/main/java/org/healtex/batch/processor/SecondPassItemProcessor.java
+++ b/src/main/java/org/healtex/batch/processor/SecondPassItemProcessor.java
@@ -4,6 +4,8 @@ import gate.*;
 import gate.creole.SerialAnalyserController;
 import gate.creole.gazetteer.DefaultGazetteer;
 import gate.util.GateRuntimeException;
+import org.healtex.batch.exception.SkipFileException;
+import org.healtex.batch.listener.FirstPassSkipFileListener;
 import org.healtex.model.AnnotatedDocument;
 import org.healtex.model.Document;
 import org.slf4j.Logger;
@@ -39,6 +41,10 @@ public class SecondPassItemProcessor implements ItemProcessor<Document, Annotate
 
     @Override
     public AnnotatedDocument process(final Document doc) throws Exception {
+        if (FirstPassSkipFileListener.getSkippedFileNames().contains(doc.getFileName())) {
+            throw new SkipFileException(doc.getFileName() + " has been skipped in first pass of the job, will be skipped in second pass as well.");
+            // TODO potentially, instead of skipping the entire pipeline for this file, maybe we write a dummy file to tell the user this file failed?
+        }
         AnnotatedDocument annotatedDoc = new AnnotatedDocument();
 
         annotatedDoc.setFileName(doc.getFileName());


### PR DESCRIPTION
#8 .. It is one of the many ways to do it.. a bit opinionated here.

It is without proper error logging now, do we want to log to a separate file, or log to the output file itself? (e.g. if pat01-01.txt failed, when I open pat01-01.txt in the output folder, it may contain "this file has failed anonymization" literally as content)?

@RichJackson we don't seem to need ExecutionContext for this?